### PR TITLE
Add a props_json column and migration code

### DIFF
--- a/mod_admin_audit.erl
+++ b/mod_admin_audit.erl
@@ -26,7 +26,9 @@
 
     observe_audit_log/2,
 
-    observe_search_query/2
+    observe_search_query/2,
+
+    observe_tick_1h/2
 ]).
 
 -include_lib("zotonic.hrl").
@@ -52,6 +54,9 @@ observe_search_query(#search_query{search={audit, Args}}, Context) ->
 
 observe_search_query(#search_query{}, _Context) ->
     undefined.
+
+observe_tick_1h(tick_1h, Context) ->
+    m_audit:periodic_cleanup(Context).
 
 audit_unique_logons(Args, _Context) ->
     {date_start, DateStart} = proplists:lookup(date_start, Args),

--- a/mod_admin_audit.erl
+++ b/mod_admin_audit.erl
@@ -8,7 +8,7 @@
 -mod_title("Admin audit functionality").
 -mod_description("Support audit log of important actions.").
 -mod_prio(1).
--mod_schema(3).
+-mod_schema(4).
 -mod_depends([admin, menu]).
 -mod_provides([audit]).
 
@@ -239,6 +239,4 @@ group_period_at_tz(week, TZ) when is_list(TZ) ->
      {"iso_week", "(extract(isoyear from (created at time zone '" ++ TZ ++ "'))::int, extract(week from (created at time zone '" ++ TZ ++ "'))::int) as iso_week"} ;
 group_period_at_tz(month, TZ) when is_list(TZ) ->
     {"iso_month", "(extract(year from (created at time zone '" ++ TZ ++ "'))::int, extract(month from (created at time zone '" ++ TZ ++ "'))::int) as iso_month"}.
-
-
 

--- a/models/m_audit.erl
+++ b/models/m_audit.erl
@@ -24,8 +24,7 @@
 
     periodic_cleanup/1,
 
-    props_json_update/1,
-    audit_record_to_prop_json/2
+    update_audit_table/1
 ]).
 
 -include_lib("zotonic.hrl").
@@ -140,7 +139,18 @@ user_agent_id(UserAgent, Context) ->
 periodic_cleanup(Context) ->
     z_db:q("delete from audit where id in (select id from audit where created < now() - interval '2 years' limit 10000)", Context, 300000).
 
-%% [TODO]Needs a function which can spawn the update procedure, so it can be initiaded from a postback
+
+% Update all records in the audit table
+update_audit_table(Context) ->
+    io:fwrite(standard_error, "Updating audit table", []),
+    case props_json_update(Context) of
+        {ok, N} when N > 0 ->
+            io:fwrite(standard_error, ".", []),
+            update_audit_table(Context);
+        {ok, 0} ->
+            io:fwrite(standard_error, ".~n", []),
+            done
+    end.
 
 % Move the stored props of erlang term props to json term props.
 props_json_update(Context) ->

--- a/models/m_audit.erl
+++ b/models/m_audit.erl
@@ -136,7 +136,7 @@ user_agent_id(UserAgent, Context) ->
 
 % Remove entries older than 2 years.
 periodic_cleanup(Context) ->
-    z_db:q("delete from audit where id in (select id from audit where created < now() - interval '2 years' limit 10000)", Context).
+    z_db:q("delete from audit where id in (select id from audit where created < now() - interval '2 years' limit 10000)", Context, 300000).
 
 
 manage_schema(install, Context) ->

--- a/models/m_audit.erl
+++ b/models/m_audit.erl
@@ -143,10 +143,13 @@ periodic_cleanup(Context) ->
 % Update all records in the audit table
 update_audit_table(Context) ->
     io:fwrite(standard_error, "Updating audit table", []),
+    update_audit_table1(Context).
+
+update_audit_table1(Context) ->
     case props_json_update(Context) of
         {ok, N} when N > 0 ->
             io:fwrite(standard_error, ".", []),
-            update_audit_table(Context);
+            update_audit_table1(Context);
         {ok, 0} ->
             io:fwrite(standard_error, ".~n", []),
             done


### PR DESCRIPTION
This PR adds 

- a `props_json` column to the audit table. Also adds code to migrate the data from the `props` to the `props_json` column.
- Code, which periodically cleans up 2 year old audit data.

**Note**
In order for this code to work, zotonic must be updated to add `props_json` handling. See: https://github.com/zotonic/zotonic/pull/2450